### PR TITLE
Open links in a new tab/window

### DIFF
--- a/layouts/partials/single-link.html
+++ b/layouts/partials/single-link.html
@@ -8,7 +8,7 @@
 <blockquote>
     {{ .Content |safeHTML }}
     <cite>
-    <a href="{{ .Params.source_url }}">source</a>
+    <a href="{{ .Params.source_url }}" target="_blank">source</a>
     </cite>
 </blockquote>
 </article>


### PR DESCRIPTION
Clicking on a link's source should open it in a new tab/window.