### PR TITLE
Add tool to calculate edition number from date, and new linter rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ Field values can be passed in during command invocation. When not set, tool will
 
 This tool manages only metadata (front matter). You still need to add link excerpt by editing the file.
 
+### edition-num-for-date
+
+Tells edition number for specified date. Support unlimited number of arguments.
+
+```
+./tools/edition-num-for-date.py 2020-01-06 2020-01-13
+./tools/edition-num-for-date.py 01/06/2020 01.06.2020 01062020
+./tools/edition-num-for-date.py content/posts/2020-01-06.md
+./tools/edition-num-for-date.py -w content/posts/2020-01-06.md
+```
+
+Date segments can be delimited using `-`, `.`, `/` or nothing at all. When year is the last component, order of day and month is determined using system locale - if locale contains `_US`, it is assumed that month is specified first, and day second (`%m-%d-%Y`). Otherwise, day is assumed to be first (`%d-%m-%Y`).
+
+Argument can be path to file, but that file must exist. Date will be read from file name.
+
+Optional `-w`/`--write` flag can be used to automatically set post metadata to value calculated by tool. Obviously that applies only to arguments that are paths to files.
+
 ### unclaimed-links
 
 Lists links that exist in source, but are not part of any post (edition).

--- a/tools/edition-num-for-date.py
+++ b/tools/edition-num-for-date.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+
+import click
+
+from helpers import EditionNumber
+from helpers import HugoContent
+
+
+def set_edition_number_for_file(path, edition_number, context):
+    metadata = context.get_metadata(path)
+    edition_in_metadata = metadata['edition']
+    if edition_in_metadata == edition_number:
+        return
+    metadata['edition'] = edition_number
+    context.set_metadata(path, metadata)
+
+
+@click.command()
+@click.option(
+    '--write/--no-write', '-w',
+    default=False,
+    help="Set calculated edition number in file metadata"
+)
+@click.argument('dates', nargs=-1)
+def main(write, dates):
+    if write:
+        content_manager = HugoContent()
+
+    for date in dates:
+        p = Path(date).resolve()
+        if p.exists():
+            edition_number = EditionNumber.from_path(p)
+            if write:
+                set_edition_number_for_file(p, edition_number, content_manager)
+        else:
+            edition_number = EditionNumber.from_date(date)
+        print(f"{date} is edition number: {edition_number}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -5,6 +5,7 @@ import hashlib
 import click
 
 from helpers import HugoContent
+from helpers import EditionNumber
 
 
 class RuleCheckFailedError(Exception):
@@ -99,6 +100,24 @@ class NoDuplicateEditions(Rule):
                 msg = f"{path.name} contains the same edition id as {editions[this_edition].name}"
                 self.fail(msg)
             editions[this_edition] = path
+
+
+class EditionNumberIsCorrect(Rule):
+    description = "Is 'edition' metadata correct for post on this date?"
+
+    def execute(self):
+        for path in self.context.posts:
+            # we started counting in May in 2018, so skip that year
+            year, _ = path.stem.split('-', 1)
+            if year == '2018':
+                continue
+
+            metadata = self.context.get_metadata(path)
+            edition_in_metadata = metadata.get('edition')
+            calculated_edition = EditionNumber.from_path(path)
+            if edition_in_metadata != calculated_edition:
+                msg = f"{path.name} edition should be {calculated_edition}, is {edition_in_metadata}"
+                self.fail(msg)
 
 
 class RequiredLinksMetadata(Rule):


### PR DESCRIPTION
@omaciel 
I wanted to add new edition, but I realized I need to be extra-careful to not make mistake in edition number, so instead I added new tool to calculate that for me.
You can feed it date string to get number in response, or you can point it to file and it will modify metadata in post.
There's also new linter rule to check that for us as we add new posts.