### PR TITLE
Add new e-mail view for posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -35,3 +35,16 @@ url = "https://github.com/AFistfulOfLinks"
 name = "RSS"
 icon = "fas fa-rss"
 url = "/index.xml"
+
+[mediaTypes]
+[mediaTypes."text/email-html"]
+suffixes = ["html"]
+
+[outputFormats]
+[outputFormats.WeeklyEmail]
+name = "WeeklyEmail"
+mediaType = "text/email-html"
+path = "email"
+
+[outputs]
+page = ["HTML", "WeeklyEmail"]

--- a/layouts/posts/single.weeklyemail.html
+++ b/layouts/posts/single.weeklyemail.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+
+<p>A Fistful of Links is a weekly newsletter about leadership, technology, books, and anything else we felt compelled to share with others, brought to you by <a href="https://twitter.com/OgMaciel">Og Maciel</a> and <a href="https://twitter.com/MirekDlugosz">Mirek Dlugosz</a>.</p>
+
+<p>Articles in this issue:</p>
+<ol>
+{{ range $link := $.Page.Params.links }}
+    {{ $linkref := print "/links/" $link }}
+    {{ with $.Site.GetPage $linkref }}
+        <li>{{ .Title }}</li>
+    {{ end }}
+{{ end }}
+</ol>
+
+<p>Happy reading!</p>
+
+<p>
+{{- range .AlternativeOutputFormats -}}
+{{- if eq .Rel "canonical" -}}
+{{- $url := urls.Parse .Permalink -}}
+{{- $postlink := printf "https://afistfuloflinks.github.io%s" $url.Path -}}
+<a href="{{ $postlink }}">{{ $postlink }}</a>
+{{- end -}}
+{{- end -}}</p>
+{{ end }}


### PR DESCRIPTION
Hey @omaciel 

Ever since we switched to Hugo, I wondered: could Hugo generate email for us, too?
Turns out, it can :) - and it wasn't even that hard.

After running `hugo serve -F`, open your edition in web browser and put "email/" between hostname and path. E.g. if edition URL is http://localhost:1313/posts/2021-02-22/, then open http://localhost:1313/email/posts/2021-02-22/ .

Page content that is displayed is ready to be copy-pasted into GMail. There are some minor differences in vertical spacing when compared to emails we were sending so far, but for me, that is small price to pay for having email content generated automatically.

Unfortunately, there's also bigger problem introduced - site generation time doubles. On my personal computer, it increases from ≈9 seconds to ≈21 seconds. It looks like Hugo is generating this new email view for every single link, even though that doesn't make any sense at all. I have not found a way to disable single page generation for specific content type.

Let me know what you think, and hit "merge" button if you like this.